### PR TITLE
3주차: 이메일 인증 기능 구현 - 김연수

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,7 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### MAC ###
+.DS_Store
+**/.DS_Store

--- a/src/main/java/com/ssafy/sandbox/email/controller/EmailController.java
+++ b/src/main/java/com/ssafy/sandbox/email/controller/EmailController.java
@@ -1,0 +1,38 @@
+package com.ssafy.sandbox.email.controller;
+
+import com.ssafy.sandbox.email.dto.EmailDTO;
+import com.ssafy.sandbox.email.dto.EmailVerificationDTO;
+import com.ssafy.sandbox.email.dto.EmailVerificationResponse;
+import com.ssafy.sandbox.email.service.EmailService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Collections;
+import java.util.Map;
+
+@Slf4j
+@RestController
+@RequestMapping("/email")
+@RequiredArgsConstructor
+public class EmailController {
+    private final EmailService emailService;
+
+    @PostMapping
+    public ResponseEntity<Map<String, Boolean>> sendVerificationEmail(@RequestBody EmailDTO emailDto) {
+        boolean isOk = emailService.sendVerificationEmail(emailDto.getEmail());
+        log.info("Email verification email sent: {}", isOk);
+        return ResponseEntity.ok(Collections.singletonMap("isOk", isOk));
+    }
+
+    @PostMapping("/authentication")
+    public EmailVerificationResponse verifyEmail(@RequestBody EmailVerificationDTO verificationDto) {
+        boolean isSuccess = emailService.verifyCode(verificationDto);
+
+        return new EmailVerificationResponse(isSuccess);
+    }
+}

--- a/src/main/java/com/ssafy/sandbox/email/dto/EmailDTO.java
+++ b/src/main/java/com/ssafy/sandbox/email/dto/EmailDTO.java
@@ -1,0 +1,14 @@
+package com.ssafy.sandbox.email.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class EmailDTO {
+    private String email;
+}

--- a/src/main/java/com/ssafy/sandbox/email/dto/EmailVerification.java
+++ b/src/main/java/com/ssafy/sandbox/email/dto/EmailVerification.java
@@ -1,0 +1,32 @@
+package com.ssafy.sandbox.email.dto;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class EmailVerification {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String email;
+    private String verificationCode;
+    private LocalDateTime expiryDate;
+    private boolean verified;
+
+    public void verify() {
+        this.verified = true;
+    }
+}

--- a/src/main/java/com/ssafy/sandbox/email/dto/EmailVerificationDTO.java
+++ b/src/main/java/com/ssafy/sandbox/email/dto/EmailVerificationDTO.java
@@ -1,0 +1,15 @@
+package com.ssafy.sandbox.email.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class EmailVerificationDTO {
+    private String email;
+    private String authentication;
+}

--- a/src/main/java/com/ssafy/sandbox/email/dto/EmailVerificationResponse.java
+++ b/src/main/java/com/ssafy/sandbox/email/dto/EmailVerificationResponse.java
@@ -1,0 +1,15 @@
+package com.ssafy.sandbox.email.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class EmailVerificationResponse {
+    private Boolean isSuccess;
+
+}

--- a/src/main/java/com/ssafy/sandbox/email/repository/EmailVerificationRepository.java
+++ b/src/main/java/com/ssafy/sandbox/email/repository/EmailVerificationRepository.java
@@ -1,0 +1,18 @@
+package com.ssafy.sandbox.email.repository;
+
+import com.ssafy.sandbox.email.dto.EmailVerification;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@Repository
+public interface EmailVerificationRepository extends JpaRepository<EmailVerification, Long> {
+    Optional<EmailVerification> findByEmailAndVerifiedFalse(String email);
+    Optional<EmailVerification> findByEmailAndVerificationCodeAndVerifiedFalse(String email, String verificationCode);
+
+    @Modifying
+    void deleteByExpiryDateLessThan(LocalDateTime expiryDate);
+}

--- a/src/main/java/com/ssafy/sandbox/email/service/EmailService.java
+++ b/src/main/java/com/ssafy/sandbox/email/service/EmailService.java
@@ -1,0 +1,83 @@
+package com.ssafy.sandbox.email.service;
+
+import com.ssafy.sandbox.email.dto.EmailVerification;
+import com.ssafy.sandbox.email.dto.EmailVerificationDTO;
+import com.ssafy.sandbox.email.repository.EmailVerificationRepository;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.Random;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class EmailService {
+    private final JavaMailSender emailSender;
+    private final EmailVerificationRepository emailVerificationRepository;
+
+    @Value("${spring.mail.username}")
+    private String fromEmail;
+
+    public boolean sendVerificationEmail(String toEmail) {
+        try {
+            // 이전 미인증 코드 삭제
+            emailVerificationRepository.findByEmailAndVerifiedFalse(toEmail)
+                    .ifPresent(emailVerificationRepository::delete);
+
+            // 새로운 인증 코드 생성
+            String verificationCode = generateVerificationCode();
+
+            log.info("Sending verification : " + verificationCode);
+            // 이메일 발송
+            MimeMessage message = emailSender.createMimeMessage();
+            MimeMessageHelper helper = new MimeMessageHelper(message, false, "UTF-8");
+
+            log.info("Sending verification email to " + toEmail);
+            helper.setFrom(fromEmail);
+            helper.setTo(toEmail);
+            helper.setSubject("이메일 인증 코드");
+            helper.setText("인증 코드: " + verificationCode);
+            log.info("it's fine");
+            emailSender.send(message);
+
+            // DB에 저장
+            EmailVerification verification = EmailVerification.builder()
+                    .email(toEmail)
+                    .verificationCode(verificationCode)
+                    .expiryDate(LocalDateTime.now().plusMinutes(5))
+                    .verified(false)
+                    .build();
+
+            emailVerificationRepository.save(verification);
+            log.info("이메일 전송 성공: {}", toEmail);
+            return true;
+        } catch (Exception e) {
+            log.error(e.getMessage());
+            log.info("이메일 전송 실패: {}", e.getMessage());
+            return false;
+        }
+    }
+
+    public boolean verifyCode(EmailVerificationDTO verificationDto) {
+        return emailVerificationRepository
+                .findByEmailAndVerificationCodeAndVerifiedFalse(verificationDto.getEmail(), verificationDto.getAuthentication())
+                .filter(verification -> verification.getExpiryDate().isAfter(LocalDateTime.now()))
+                .map(verification -> {
+                    verification.verify();
+                    emailVerificationRepository.save(verification);
+                    return true;
+                })
+                .orElse(false);
+    }
+
+    private String generateVerificationCode() {
+        Random random = new Random();
+        return String.format("%06d", random.nextInt(1000000));
+    }
+}


### PR DESCRIPTION
## 📝 작업 내용
 - Email 주소를 받아 랜덤 코드를 보내고 인증 코드가 맞는 지 확인하는 로직 구현
 - 5분마다 만료기한이 지난 인증 데이터들을 제거
## 💬 리뷰 포인트
 - repository에서 인증 데이터 삭제 메소드 호출 시, "cannot reliably process 'remove' call" 에러 발생
 - @Modifying 어노테이션을 붙여 해결.
## 🚀 학습에 도움을 줄만한 자료
- @Modifying(
    clearAutomatically = true,  // 영속성 컨텍스트 자동 초기화
    flushAutomatically = true   // 쿼리 실행 전 자동 플러시
)
- @Modifying은 벌크연산(delete, update로 대량의 데이터 한 꺼번에 처리)을 할 때 사용한다고 합니다. -> 추후 자세히 학습
- 영속성 컨텍스트란? -> 추후 학습하도록 하겠습니다.
- 관련 링크 : https://hstory0208.tistory.com/entry/JPA-Modifying%EC%9D%B4%EB%9E%80-%EA%B7%B8%EB%A6%AC%EA%B3%A0-%EC%A3%BC%EC%9D%98%ED%95%A0%EC%A0%90-%EB%B2%8C%ED%81%AC-%EC%97%B0%EC%82%B0